### PR TITLE
Add project status and getting involved sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,15 @@ MIT
 - [Stacks Documentation](https://docs.stacks.co)
 - [Clarity Language](https://book.clarity-lang.org)
 - [RainbowKit](https://rainbowkit.com)
+
+---
+
+## Project Status
+
+🚀 **Active Development** - This project is under active development and welcomes contributions.
+
+## Getting Involved
+
+- Check out our [Contributing Guidelines](./CONTRIBUTING.md)
+- Join the discussion in [GitHub Issues](../../issues)
+- Follow development updates


### PR DESCRIPTION
This PR adds a project status section to the README that indicates active development and provides guidance on how contributors can get involved with the project.

## Changes Made
- Added project status section with active development notice
- Added getting involved section with links to contributing guidelines and GitHub issues
- Improved documentation for potential contributors

## Impact
- Better project discoverability for contributors
- Clear indication of project status
- Easier onboarding for new contributors