### PR TITLE
Add Transaction Post-Conditions (#28)

### DIFF
--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -102,3 +102,12 @@ export function validatePostCondition(condition: AnyPostCondition): boolean {
 export function getPostConditionSummary(condition: AnyPostCondition): string {
   return \`\${condition.type}: \${condition.comparator} \${condition.amount}\`;
 }
+
+export interface PostConditionGroup {
+  conditions: AnyPostCondition[];
+  message?: string;
+}
+
+export function createPostConditionGroup(conditions: AnyPostCondition[]): PostConditionGroup {
+  return { conditions };
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -92,3 +92,9 @@ export function serializePostConditions(conditions: AnyPostCondition[]): string 
 export function deserializePostConditions(data: string): AnyPostCondition[] {
   return JSON.parse(data);
 }
+
+export function validatePostCondition(condition: AnyPostCondition): boolean {
+  if (!condition.type) return false;
+  if (!condition.comparator) return false;
+  return true;
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -146,3 +146,11 @@ export function combinePostConditions(
 ): AnyPostCondition[] {
   return groups.flatMap(g => g.conditions);
 }
+
+export default {
+  PostConditionBuilder,
+  PostConditionManager,
+  createPostCondition,
+  serializePostConditions,
+  validatePostCondition,
+};

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -140,3 +140,9 @@ export class PostConditionManager {
     this.conditions = [];
   }
 }
+
+export function combinePostConditions(
+  groups: PostConditionGroup[]
+): AnyPostCondition[] {
+  return groups.flatMap(g => g.conditions);
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -4,3 +4,16 @@
 export type PostConditionType = 'stx' | 'ft' | 'nft';
 
 export type PostConditionMode = 'allow' | 'deny';
+
+export type PostConditionComparator = 
+  | 'eq' 
+  | 'gt' 
+  | 'gte' 
+  | 'lt' 
+  | 'lte';
+
+export interface PostConditionBase {
+  type: PostConditionType;
+  comparator: PostConditionComparator;
+  mode: PostConditionMode;
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -111,3 +111,10 @@ export interface PostConditionGroup {
 export function createPostConditionGroup(conditions: AnyPostCondition[]): PostConditionGroup {
   return { conditions };
 }
+
+export function filterConditionsByType(
+  conditions: AnyPostCondition[],
+  type: PostConditionType
+): AnyPostCondition[] {
+  return conditions.filter(c => c.type === type);
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -52,3 +52,13 @@ export class PostConditionBuilder {
     return this;
   }
 }
+
+  addFT(
+    assetId: string,
+    amount: bigint,
+    comparator: PostConditionComparator,
+    sender?: string
+  ): this {
+    this.conditions.push({ type: 'ft', assetId, amount, comparator, mode: 'allow', sender });
+    return this;
+  }

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -76,3 +76,11 @@ export class PostConditionBuilder {
     return this.conditions;
   }
 }
+
+export function createPostCondition(
+  type: PostConditionType,
+  comparator: PostConditionComparator,
+  amount: bigint
+): AnyPostCondition {
+  return { type, comparator, amount, mode: 'allow' };
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -62,3 +62,12 @@ export class PostConditionBuilder {
     this.conditions.push({ type: 'ft', assetId, amount, comparator, mode: 'allow', sender });
     return this;
   }
+
+  addNFT(
+    assetId: string,
+    tokenId: bigint,
+    sender?: string
+  ): this {
+    this.conditions.push({ type: 'nft', assetId, tokenId, comparator: 'eq', mode: 'allow', sender });
+    return this;
+  }

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -37,3 +37,18 @@ export interface NFTPostCondition extends PostConditionBase {
   assetId: string;
   sender?: string;
 }
+
+export type AnyPostCondition = STXPostCondition | FTPostCondition | NFTPostCondition;
+
+export class PostConditionBuilder {
+  private conditions: AnyPostCondition[] = [];
+  
+  addSTX(
+    amount: bigint,
+    comparator: PostConditionComparator,
+    sender?: string
+  ): this {
+    this.conditions.push({ type: 'stx', amount, comparator, mode: 'allow', sender });
+    return this;
+  }
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -118,3 +118,9 @@ export function filterConditionsByType(
 ): AnyPostCondition[] {
   return conditions.filter(c => c.type === type);
 }
+
+export const POST_CONDITION_ERRORS = {
+  INVALID_TYPE: 'Invalid post-condition type',
+  INVALID_COMPARATOR: 'Invalid comparator',
+  MISSING_AMOUNT: 'Amount is required',
+} as const;

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -71,3 +71,8 @@ export class PostConditionBuilder {
     this.conditions.push({ type: 'nft', assetId, tokenId, comparator: 'eq', mode: 'allow', sender });
     return this;
   }
+
+  build(): AnyPostCondition[] {
+    return this.conditions;
+  }
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -124,3 +124,19 @@ export const POST_CONDITION_ERRORS = {
   INVALID_COMPARATOR: 'Invalid comparator',
   MISSING_AMOUNT: 'Amount is required',
 } as const;
+
+export class PostConditionManager {
+  private conditions: AnyPostCondition[] = [];
+  
+  add(condition: AnyPostCondition): void {
+    this.conditions.push(condition);
+  }
+  
+  getAll(): AnyPostCondition[] {
+    return this.conditions;
+  }
+  
+  clear(): void {
+    this.conditions = [];
+  }
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -98,3 +98,7 @@ export function validatePostCondition(condition: AnyPostCondition): boolean {
   if (!condition.comparator) return false;
   return true;
 }
+
+export function getPostConditionSummary(condition: AnyPostCondition): string {
+  return \`\${condition.type}: \${condition.comparator} \${condition.amount}\`;
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -30,3 +30,10 @@ export interface FTPostCondition extends PostConditionBase {
   assetId: string;
   sender?: string;
 }
+
+export interface NFTPostCondition extends PostConditionBase {
+  type: 'nft';
+  tokenId: bigint;
+  assetId: string;
+  sender?: string;
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -88,3 +88,7 @@ export function createPostCondition(
 export function serializePostConditions(conditions: AnyPostCondition[]): string {
   return JSON.stringify(conditions);
 }
+
+export function deserializePostConditions(data: string): AnyPostCondition[] {
+  return JSON.parse(data);
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -17,3 +17,9 @@ export interface PostConditionBase {
   comparator: PostConditionComparator;
   mode: PostConditionMode;
 }
+
+export interface STXPostCondition extends PostConditionBase {
+  type: 'stx';
+  amount: bigint;
+  sender?: string;
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -84,3 +84,7 @@ export function createPostCondition(
 ): AnyPostCondition {
   return { type, comparator, amount, mode: 'allow' };
 }
+
+export function serializePostConditions(conditions: AnyPostCondition[]): string {
+  return JSON.stringify(conditions);
+}

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -1,0 +1,6 @@
+// Transaction Post-Conditions
+// Provides post-condition builders for Stacks transactions
+
+export type PostConditionType = 'stx' | 'ft' | 'nft';
+
+export type PostConditionMode = 'allow' | 'deny';

--- a/frontend/src/lib/post-conditions.ts
+++ b/frontend/src/lib/post-conditions.ts
@@ -23,3 +23,10 @@ export interface STXPostCondition extends PostConditionBase {
   amount: bigint;
   sender?: string;
 }
+
+export interface FTPostCondition extends PostConditionBase {
+  type: 'ft';
+  amount: bigint;
+  assetId: string;
+  sender?: string;
+}


### PR DESCRIPTION
## Summary
- Implemented comprehensive post-condition builders for Stacks transactions
- Added support for STX, FT, and NFT post-conditions
- Included condition groups and manager class
- Added serialization, validation, and filtering utilities

Closes #28